### PR TITLE
#88528 add Magento ProductMetadata view model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- DEV-88528: replace ObjectManager in phtml
 
 ## [1.5.0] - 2022-02-22
 ### Removed

--- a/ViewModel/ProductMetadata.php
+++ b/ViewModel/ProductMetadata.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Snowdog\AlpacaGeneral\ViewModel;
+
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+
+class ProductMetadata implements ArgumentInterface
+{
+    /**
+     * @var ProductMetadataInterface
+     */
+    private $productMetadata;
+
+    public function __construct(ProductMetadataInterface $productMetadata)
+    {
+        $this->productMetadata = $productMetadata;
+    }
+
+    public function getEdition() : string
+    {
+        return $this->productMetadata->getEdition();
+    }
+
+    public function isB2B(): bool
+    {
+        return $this->getEdition() == 'B2B';
+    }
+}


### PR DESCRIPTION
This adds necessary logic for implementing view models in alpaca theme in order to remove ObjectManager usage in template files.